### PR TITLE
Retry execution of firmadyne console after error

### DIFF
--- a/drivers/firmadyne/hooks.c
+++ b/drivers/firmadyne/hooks.c
@@ -256,13 +256,16 @@ static void open_hook(int dfd, const char __user *filename, int flags, umode_t m
 static void execve_hook(const char *filename, const char __user *const __user *argv, const char __user *const __user *envp) {
 	int i;
 	static char *argv_init[] = { "/firmadyne/console", NULL };
+	int rv;
 
 	if (execute > 5) {
 		execute = 0;
-
 		printk(KERN_INFO MODULE_NAME": do_execve: %s\n", argv_init[0]);
-		call_usermodehelper(argv_init[0], argv_init, envp_init, UMH_NO_WAIT);
-
+		rv = call_usermodehelper(argv_init[0], argv_init, envp_init, UMH_WAIT_EXEC);
+		if (rv != 0) {
+			printk("Firmadyne console failed to start: error %d, will retry again soon\n", rv);
+			execute = 1;
+		}
 		printk(KERN_WARNING "OFFSETS: offset of pid: 0x%x offset of comm: 0x%x\n", offsetof(struct task_struct, pid), offsetof(struct task_struct, comm));
 	}
 	else if (execute > 0) {


### PR DESCRIPTION
For some firmwares I see the execution of`/firmadyne/console` fail with error -2. I suspect this is caused by the filesystem not being fully set up by the time the 5th `execve` is triggered. This PR detects these sorts of failures by using running `call_usermodehelper` with `UMH_WAIT_EXEC` instead of `UMH_NO_WAIT` and checking the error code.

If there are systems where the console binary is missing, this new current design would log a warning every 5 execs which might be a bit too verbose? But it should make the process of getting a shell much more reliable. Happy to adjust this change if anyone has suggestions for another way to ensure the shell gets started if it fails at first (perhaps increasing the number of execs it waits for every time it retries?)